### PR TITLE
修复灵兽超进化几个活动BUG

### DIFF
--- a/src/com/taomee/seer2/app/processor/map/MapProcessor_80318.as
+++ b/src/com/taomee/seer2/app/processor/map/MapProcessor_80318.as
@@ -19,6 +19,7 @@ import com.taomee.seer2.core.map.MapProcessor;
 import com.taomee.seer2.core.module.ModuleManager;
 import com.taomee.seer2.core.scene.SceneManager;
 import com.taomee.seer2.core.scene.SceneType;
+import com.taomee.seer2.core.ui.toolTip.TooltipManager;
 import com.taomee.seer2.core.utils.URLUtil;
 
 import flash.display.MovieClip;
@@ -165,6 +166,7 @@ public class MapProcessor_80318 extends MapProcessor {
             this.dreamValues = 200;
         }
         this.bar.scaleY = this.dreamValues / 200;
+        TooltipManager.addCommonTip(this.bar,this.dreamValues.toString());
         if (this.dreamValues >= 50 && this.dreamValues < 100) {
             this.setBtnEnable(this.swapList[0], true);
         } else if (this.dreamValues >= 100 && this.dreamValues < 200) {

--- a/src/com/taomee/seer2/app/yilingshouevolution/YiLingShouEvolutionManager.as
+++ b/src/com/taomee/seer2/app/yilingshouevolution/YiLingShouEvolutionManager.as
@@ -6,6 +6,7 @@ import com.taomee.seer2.app.component.MouseClickHintSprite;
 import com.taomee.seer2.app.dialog.NpcDialog;
 import com.taomee.seer2.app.manager.DayLimitManager;
 import com.taomee.seer2.app.net.parser.Parser_1142;
+import com.taomee.seer2.app.popup.AlertManager;
 import com.taomee.seer2.app.scene.LobbyPanel;
 import com.taomee.seer2.app.serverBuffer.ServerBuffer;
 import com.taomee.seer2.app.serverBuffer.ServerBufferManager;
@@ -198,6 +199,11 @@ public class YiLingShouEvolutionManager {
     private static function onSwap(param1:MouseEvent):void {
         var e:MouseEvent = param1;
         var idx:int = swapBtnList.indexOf(e.currentTarget as SimpleButton);
+        if(idx < 2)
+        {
+            AlertManager.showAlert("领取该道具会消耗对应进度,改服暂时屏蔽\n若仍要领取,请前往官服");
+            return;
+        }
         SwapManager.swapItem(3883, 1, function (param1:IDataInput):void {
             new SwapInfo(param1);
             updateDate();

--- a/src/com/taomee/seer2/app/yuelingshouevolution/YueLingShouEvolutionManager.as
+++ b/src/com/taomee/seer2/app/yuelingshouevolution/YueLingShouEvolutionManager.as
@@ -6,6 +6,7 @@ import com.taomee.seer2.app.dialog.NpcDialog;
 import com.taomee.seer2.app.inventory.ItemManager;
 import com.taomee.seer2.app.manager.DayLimitManager;
 import com.taomee.seer2.app.net.parser.Parser_1142;
+import com.taomee.seer2.app.popup.AlertManager;
 import com.taomee.seer2.app.popup.ServerMessager;
 import com.taomee.seer2.app.scene.LobbyPanel;
 import com.taomee.seer2.app.serverBuffer.ServerBuffer;
@@ -264,6 +265,11 @@ public class YueLingShouEvolutionManager {
     private static function onSwap(param1:MouseEvent):void {
         var e:MouseEvent = param1;
         var idx:int = swapBtnList.indexOf(e.currentTarget as SimpleButton);
+        if(idx < 2)
+        {
+            AlertManager.showAlert("领取该道具会消耗对应进度,改服暂时屏蔽\n若仍要领取,请前往官服");
+            return;
+        }
         SwapManager.swapItem(3928, 1, function (param1:IDataInput):void {
             new SwapInfo(param1);
             updateDate();

--- a/src/com/taomee/seer2/app/zhaoLingShouEvolution/ZhaoLingShouEvolutionManager.as
+++ b/src/com/taomee/seer2/app/zhaoLingShouEvolution/ZhaoLingShouEvolutionManager.as
@@ -350,7 +350,7 @@ public class ZhaoLingShouEvolutionManager {
             _loc3_++;
         }
         var _loc4_:int = (_loc4_ = int(param1.infoVec[1])) > 200 ? 200 : _loc4_;
-        this._barMc.gotoAndStop(_loc4_);
+        this._barMc.gotoAndStop(int(_loc4_ / 2));
         TooltipManager.addCommonTip(this._barMc, _loc4_.toString());
         this._mainUI.visible = true;
     }


### PR DESCRIPTION
修复: 
1.幻灵兽超进化进度条不显示具体数值;
2.月灵,翼灵兽超进化领取道具减进度(直接不允许领取);
3.爪灵兽超进化进度条显示错误.